### PR TITLE
fixed superman singleton synchronizing different class

### DIFF
--- a/src/main/java/info/multithreading/problems/superman/Superman.java
+++ b/src/main/java/info/multithreading/problems/superman/Superman.java
@@ -11,7 +11,7 @@ public class Superman {
     public static Superman getInstance() {
 
         if (superman == null) {
-            synchronized (SupermanSlightlyBetter.class) {
+            synchronized (Superman.class) {
 
                 if (superman == null) {
                     superman = new Superman();


### PR DESCRIPTION
In superman singleton class, creating new singleton instance on getInstance method was pointing to different class.